### PR TITLE
Add extra template options and improve test coverage

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+group :integration do
+  cookbook 'test', path: './test/fixtures/cookbooks/test'
+end

--- a/attributes/oauth2_proxy.rb
+++ b/attributes/oauth2_proxy.rb
@@ -1,8 +1,7 @@
 
-default[:oauth2_proxy][:source] = "https://github.com/bitly/oauth2_proxy/releases/download/v2.0.1/oauth2_proxy-2.0.1.linux-amd64.go1.4.2.tar.gz"
-default[:oauth2_proxy][:checksum] = "c6d8f6d74e1958ce1688f3cf7d60648b9d0d6d4344d74c740c515a00b4e023ad"
-default[:oauth2_proxy][:install_mode] = "source"
+default['oauth2_proxy']['source'] = 'https://github.com/bitly/oauth2_proxy/releases/download/v2.0.1/oauth2_proxy-2.0.1.linux-amd64.go1.4.2.tar.gz'
+default['oauth2_proxy']['checksum'] = 'c6d8f6d74e1958ce1688f3cf7d60648b9d0d6d4344d74c740c515a00b4e023ad'
+default['oauth2_proxy']['install_mode'] = 'source'
 
-default[:oauth2_proxy][:user] = "oauth2_proxy"
-default[:oauth2_proxy][:group] = "oauth2_proxy"
-
+default['oauth2_proxy']['user'] = 'oauth2_proxy'
+default['oauth2_proxy']['group'] = 'oauth2_proxy'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,5 +8,5 @@ version '0.2.0'
 
 depends 'common_attrs'
 depends 'golang', '~> 1.7.0'
-depends 'apt', '~> 3.0'
+depends 'apt'
 depends 'ark', '~> 1.0.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,4 +5,8 @@ license 'apache2'
 description 'Installs/Configures oauth2_proxy'
 long_description 'Installs/Configures oauth2_proxy'
 version '0.2.0'
+
 depends 'common_attrs'
+depends 'golang', '~> 1.7.0'
+depends 'apt', '~> 3.0'
+depends 'ark', '~> 1.0.1'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,7 @@
 
-case node[:oauth2_proxy][:install_mode]
-when "source" then include_recipe "#{cookbook_name}::install_source"
-when "binary" then include_recipe "#{cookbook_name}::install_binary"
+case node['oauth2_proxy']['install_mode']
+when 'source'
+  include_recipe "#{cookbook_name}::install_source"
+when 'binary'
+  include_recipe "#{cookbook_name}::install_binary"
 end
-

--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -1,30 +1,13 @@
 
 # Create a user for the service
 #
-user "oauth2_proxy"
+user 'oauth2_proxy'
 
 # Download the oauth2_proxy binary
 #
-tarball_path = "#{Chef::Config['file_cache_path']}/oauth2_proxy.tgz"
-
-remote_file tarball_path do
-  source node[:oauth2_proxy][:source]
-  checksum node[:oauth2_proxy][:checksum]
-  notifies :run, "bash[extract #{tarball_path}]", :immediately
+ark 'oauth2_proxy' do
+  url node['oauth2_proxy']['source']
+  checksum node['oauth2_proxy']['checksum']
+  prefix_bin '/usr/local/bin/'
+  has_binaries ['oauth2_proxy']
 end
-
-bash "extract #{tarball_path}" do
-  cwd "#{Chef::Config['file_cache_path']}"
-  code <<-EOH
-    tar --strip-components=1 -xzf #{tarball_path}
-  EOH
-  action :nothing
-end
-
-remote_file "/usr/local/bin/oauth2_proxy" do
-  source "file://#{Chef::Config['file_cache_path']}/oauth2_proxy"
-  owner "oauth2_proxy"
-  group "oauth2_proxy"
-  mode  0754
-end
-

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -1,40 +1,21 @@
+# this is needed to install git in golang
+include_recipe 'apt'
+
+# installing the golang
+include_recipe 'golang'
 
 # Create a user for the service
 #
-user "oauth2_proxy"
+user 'oauth2_proxy'
 
 # Download the oauth2_proxy binary
 #
-remote_file "#{Chef::Config['file_cache_path']}/go1.4.3.linux-amd64.tar.gz" do
-  source "https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz"
-  notifies :run, "bash[extract golang]", :immediately
-  notifies :run, "bash[compile oauth2_proxy]", :immediately
-end
 
-bash "extract golang" do
-  cwd "#{Chef::Config['file_cache_path']}"
-  code <<-EOH
-    tar -zxvf "go1.4.3.linux-amd64.tar.gz"
-    mkdir go_work
-  EOH
-  action :nothing
-end
+golang_package 'github.com/bitly/oauth2_proxy'
 
-bash "compile oauth2_proxy" do
-  cwd "#{Chef::Config['file_cache_path']}"
-  environment "GOROOT" => "#{Chef::Config['file_cache_path']}/go",
-              "GOPATH" => "#{Chef::Config['file_cache_path']}/go_work",
-              "PATH" => "#{Chef::Config['file_cache_path']}/go/bin:/bin:/usr/bin:/usr/local/bin"
-  code <<-EOH
-    go get github.com/bitly/oauth2_proxy
-  EOH
-  action :nothing
+remote_file '/usr/local/bin/oauth2_proxy' do
+  source "file://#{node['go']['gobin']}/oauth2_proxy"
+  owner 'root'
+  group 'oauth2_proxy'
+  mode 0754
 end
-
-remote_file "/usr/local/bin/oauth2_proxy" do
-  source "file://#{Chef::Config['file_cache_path']}/go_work/bin/oauth2_proxy"
-  owner "root"
-  group "oauth2_proxy"
-  mode  0754
-end
-

--- a/resources/instance.rb
+++ b/resources/instance.rb
@@ -2,133 +2,138 @@
 require 'securerandom'
 
 property :listen_address,
-  kind_of: String,
-  default: "127.0.0.1"
+         kind_of: String,
+         default: '127.0.0.1'
 
 property :listen_port,
-  kind_of: Integer,
-  default: 4180
+         kind_of: Integer,
+         default: 4180
 
 property :listen_uri,
-  kind_of: String,
-  default: "/oauth2"
+         kind_of: String,
+         default: '/oauth2'
 
 property :client_id,
-  kind_of: String,
-  coerce: proc { |value| Common::Delegator::ObfuscatedType.new(value) },
-  required: true
+         kind_of: String,
+         coerce: proc { |value| Common::Delegator::ObfuscatedType.new(value) },
+         required: true
 
 property :client_secret,
-  kind_of: String,
-  coerce: proc { |value| Common::Delegator::ObfuscatedType.new(value) },
-  required: true
+         kind_of: String,
+         coerce: proc { |value| Common::Delegator::ObfuscatedType.new(value) },
+         required: true
 
 property :redirect_url,
-  kind_of: String
+         kind_of: String
 
 property :proxy_prefix,
-  kind_of: String,
-  default: "/oauth2"
+         kind_of: String,
+         default: '/oauth2'
 
 property :upstreams,
-  kind_of: Array,
-  default: Array.new
+         kind_of: Array,
+         default: []
 
 property :email_domains,
-  kind_of: Array,
-  required: true
+         kind_of: Array,
+         required: true
 
 property :request_logging,
-  kind_of: [TrueClass, FalseClass],
-  default: false
+         kind_of: [TrueClass, FalseClass],
+         default: false
 
 property :pass_access_token,
-  kind_of: [TrueClass, FalseClass],
-  default: true
+         kind_of: [TrueClass, FalseClass],
+         default: true
 
 property :pass_basic_auth,
-  kind_of: [TrueClass, FalseClass],
-  default: true
+         kind_of: [TrueClass, FalseClass],
+         default: true
 
 property :pass_host_header,
-  kind_of: [TrueClass, FalseClass],
-  default: true
+         kind_of: [TrueClass, FalseClass],
+         default: true
 
 property :custom_templates_dir,
-  kind_of: String
+         kind_of: String
 
 property :cookie_name,
-  kind_of: String,
-  default: "_oauth2_proxy"
+         kind_of: String,
+         default: '_oauth2_proxy'
 
 property :cookie_secret,
-  coerce: proc { |value| Common::Delegator::ObfuscatedType.new(value) },
-  kind_of: String,
-  default: lazy { 
-    Chef::Log.warn "#{self} setting random cookie_secret, this may break load balancing."
-    SecureRandom.hex 
-  }
+         coerce: proc { |value| Common::Delegator::ObfuscatedType.new(value) },
+         kind_of: String,
+         default: lazy {
+           Chef::Log.warn "#{self} setting random cookie_secret, this may break load balancing."
+           SecureRandom.hex
+         }
 
 property :cookie_domain,
-  kind_of: String
+         kind_of: String
 
 property :cookie_expire,
-  kind_of: String,
-  default: "12h"
+         kind_of: String,
+         default: '12h'
 
 property :cookie_refresh,
-  kind_of: String,
-  default: "1h"
+         kind_of: String,
+         default: '1h'
 
 property :cookie_secure,
-  kind_of: [TrueClass, FalseClass],
-  default: true
+         kind_of: [TrueClass, FalseClass],
+         default: true
 
 property :cookie_httponly,
-  kind_of: [TrueClass, FalseClass],
-  default: true
+         kind_of: [TrueClass, FalseClass],
+         default: true
 
 property :oauth_provider,
-  kind_of: String,
-  default: "google"
+         kind_of: String,
+         default: 'google'
 
 property :enabled,
-  kind_of: [TrueClass, FalseClass],
-  default: true
+         kind_of: [TrueClass, FalseClass],
+         default: true
+
+property :extra_opts,
+         kind_of: Hash,
+         default: {}
 
 action :create do
-  directory "/etc/oauth2_proxy" do
-    owner node[:oauth2_proxy][:user]
-    group node[:oauth2_proxy][:group]
-    mode  0750
+  directory '/etc/oauth2_proxy' do
+    owner node['oauth2_proxy']['user']
+    group node['oauth2_proxy']['group']
+    mode 0750
   end
 
   config = new_resource.to_hash
 
   template "/etc/oauth2_proxy/#{name}.conf" do
-    source "oauth2_proxy.conf.erb"
-    owner node[:oauth2_proxy][:user]
-    group node[:oauth2_proxy][:group]
-    mode  0640
-    cookbook "oauth2_proxy"
+    source 'oauth2_proxy.conf.erb'
+    owner node['oauth2_proxy']['user']
+    group node['oauth2_proxy']['group']
+    mode 0640
+    cookbook 'oauth2_proxy'
     sensitive true
     variables config
     if new_resource.enabled
-      notifies  :restart, "service[oauth2_proxy_#{new_resource.name}]"
+      notifies :restart, "service[oauth2_proxy_#{new_resource.name}]"
     end
   end
 
   template "/etc/init/oauth2_proxy_#{new_resource.name}.conf" do
-    source "oauth2_service.conf.erb"
-    owner "root"
-    group "root"
-    mode   0644
-    cookbook "oauth2_proxy"
+    source 'oauth2_service.conf.erb'
+    owner 'root'
+    group 'root'
+    mode 0644
+    cookbook 'oauth2_proxy'
     variables config_path: "/etc/oauth2_proxy/#{new_resource.name}.conf",
-              user: node[:oauth2_proxy][:user],
-              name: new_resource.name
+              user: node['oauth2_proxy']['user'],
+              name: new_resource.name,
+              extra_opts: new_resource.extra_opts
     if new_resource.enabled
-      notifies  :restart, "service[oauth2_proxy_#{new_resource.name}]"
+      notifies :restart, "service[oauth2_proxy_#{new_resource.name}]"
     end
   end
 
@@ -150,4 +155,3 @@ action :delete do
     action :delete
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,8 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+  config.platform = 'ubuntu'
+  config.version = '12.04'
+  config.log_level = :error
+end

--- a/spec/unit/recipes/install_binary_spec.rb
+++ b/spec/unit/recipes/install_binary_spec.rb
@@ -1,25 +1,30 @@
 #
 # Cookbook Name:: oauth2_proxy
-# Spec:: default
+# Spec:: install_binary
 #
 # Copyright (c) 2016 The Authors, All Rights Reserved.
 
 require 'spec_helper'
 
-describe 'oauth2_proxy::default' do
+describe 'oauth2_proxy::install_binary' do
   context 'When all attributes are default, on an unspecified platform' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new
       runner.converge(described_recipe)
     end
 
-    it 'includes the install_source recipe' do
-      stub_command("/usr/local/go/bin/go version | grep \"go1.5 \"").and_return(0)
-      expect(chef_run).to include_recipe('oauth2_proxy::install_source')
+    it 'creates the oauth2 user' do 
+      expect(chef_run).to create_user('oauth2_proxy')
+    end
+
+    it 'installs the binary with the ark provider' do
+      expect(chef_run).to install_ark('oauth2_proxy').with(
+        prefix_bin: '/usr/local/bin/',
+        has_binaries: ['oauth2_proxy']
+      )
     end
 
     it 'converges successfully' do 
-      stub_command("/usr/local/go/bin/go version | grep \"go1.5 \"").and_return(0)
       expect { chef_run }.to_not raise_error
     end
   end

--- a/spec/unit/recipes/install_source_spec.rb
+++ b/spec/unit/recipes/install_source_spec.rb
@@ -1,0 +1,42 @@
+#
+# Cookbook Name:: oauth2_proxy
+# Spec:: install_source
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'oauth2_proxy::install_source' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'creates the oauth2 user' do 
+      stub_command("/usr/local/go/bin/go version | grep \"go1.5 \"").and_return(0)
+      expect(chef_run).to create_user('oauth2_proxy')
+    end
+
+    it 'includes the apt & golang recipe' do
+      stub_command("/usr/local/go/bin/go version | grep \"go1.5 \"").and_return(0)
+      expect(chef_run).to include_recipe('apt')
+      expect(chef_run).to include_recipe('golang')
+    end
+
+    it 'installs the oauth2_proxy golang package' do
+      stub_command("/usr/local/go/bin/go version | grep \"go1.5 \"").and_return(0)
+      expect(chef_run).to install_golang_package('github.com/bitly/oauth2_proxy')
+    end
+
+    it 'creates the oauth2_proxy binary in the correct place' do
+      stub_command("/usr/local/go/bin/go version | grep \"go1.5 \"").and_return(0)
+      expect(chef_run).to create_remote_file('/usr/local/bin/oauth2_proxy')
+    end
+
+    it 'converges successfully' do 
+      stub_command("/usr/local/go/bin/go version | grep \"go1.5 \"").and_return(0)
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/templates/default/oauth2_proxy.conf.erb
+++ b/templates/default/oauth2_proxy.conf.erb
@@ -44,3 +44,7 @@ cookie_httponly = <%= @cookie_httponly %>
 
 # Providers
 provider = "<%= @oauth_provider %>"
+
+<% @extra_opts.each do |opt, value| %>
+<%= opt %> = "<%= value %>"
+<% end %>

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -1,0 +1,3 @@
+name 'test'
+version '0.0.1'
+depends 'oauth2_proxy'

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,0 +1,11 @@
+# this aims to test as much of the proxy as possible
+
+include_recipe 'oauth2_proxy::install_binary'
+
+oauth2_proxy_instance 'test' do
+  client_id 'someteststring'
+  client_secret 'supersecret'
+  email_domains ['test.com']
+  upstreams ['http://localhost:8080']
+  extra_opts(test: 'var')
+end

--- a/test/integration/binary/inspec/default_spec.rb
+++ b/test/integration/binary/inspec/default_spec.rb
@@ -1,0 +1,4 @@
+
+describe file('/usr/local/bin/oauth2_proxy') do
+  it { should be_executable }
+end

--- a/test/integration/custom_resource/default_spec.rb
+++ b/test/integration/custom_resource/default_spec.rb
@@ -1,0 +1,18 @@
+
+describe file('/usr/local/bin/oauth2_proxy') do
+  it { should be_executable }
+end
+
+describe service('oauth2_proxy_test') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe file('/etc/oauth2_proxy/test.conf') do
+  its('content') { should match(/client_id\s=\s"someteststring"/) }
+  its('content') { should match(/client_secret\s=\s"supersecret"/) }
+  its('content') { should match(/upstreams\s=\s\["http:\/\/localhost:8080"\]/) }
+  its('content') { should match(/email_domains\s=\s\["test.com"\]/) }
+  its('content') { should match(/test\s=\s"var"/) }
+end

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,0 +1,4 @@
+
+describe file('/usr/local/bin/oauth2_proxy') do
+  it { should be_executable }
+end


### PR DESCRIPTION
Hey, I was going to write exactly this, so you have saved me a job!
I've added some extra template options as I plan to use this with Azure.
Whilst doing this I am going to improve the test coverage, and clean up the cookbook a bit.

Tasks:
- [x] Refactor source install to converge correctly under ubuntu
- [x] Add a simple integration test to check the binary compiles and is executable
- [x] Fix all rubocop errors
- [x] Fix all food critic errors
- [x] Add extra_ops template options
- [x] Test extra_ops template options
- [x] Write some unit tests to validate logic in source/binary install
- [x] Add suite and fixture cookbook to test custom resource  